### PR TITLE
Feat: Implements keep-alive keyboard activity

### DIFF
--- a/openspec/changes/archive/2026-01-01-keep-alive-keyboard-activity/design.md
+++ b/openspec/changes/archive/2026-01-01-keep-alive-keyboard-activity/design.md
@@ -1,0 +1,467 @@
+# Keep-Alive Keyboard Activity Design
+
+## Context
+
+AIPut 是一个运行在 Linux 桌面环境的无线语音输入工具。在 Fedora 系统上，当用户长时间不进行输入操作时，系统会弹出键盘输入相关的提示或检测通知。这会影响用户体验，因为需要手动关闭提示窗口，并可能导致 AIPut 的自动化输入被系统中断。
+
+当前项目已经具备跨平台适配器架构，支持 X11 和 Wayland 显示服务器，并使用 `pyautogui` 等库实现键盘模拟功能。我们需要在此基础上实现一个后台保持激活机制。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 实现跨平台的保持激活机制，防止系统检测到空闲状态
+- 使用通用的 `keep_alive()` 接口，允许各平台选择最合适的实现方式
+- Linux 平台（特别是 Fedora/KDE）使用 Scroll Lock 按键实现
+- 使用独立线程实现，避免阻塞主服务
+- 支持可配置的触发间隔
+- 确保与 X11/Wayland 的兼容性
+
+**Non-Goals:**
+- 修改系统电源管理设置（不涉及 suspend/hibernate）
+- 防止屏幕锁定或屏保启动
+- 鼠标移动模拟（只使用键盘事件）
+- 复杂的空闲检测逻辑（使用固定间隔触发）
+- 强制所有平台使用相同的实现方式
+
+## Decisions
+
+### Decision 1: 使用通用接口名 `keep_alive()`
+
+**选择理由：**
+- 接口名应该描述功能意图而非具体实现
+- 不同平台可能需要不同的保持激活策略
+- Linux (Fedora/KDE) 使用 Scroll Lock 是针对该平台的最佳实践
+- 其他平台可以返回 False（表示不需要此功能）或采用其他实现
+
+**架构优势：**
+```python
+# 基类定义通用接口
+class KeyboardAdapter(ABC):
+    @abstractmethod
+    async def keep_alive(self) -> bool:
+        """Keep system active to prevent idle detection.
+
+        Each platform adapter decides the best implementation:
+        - Linux: Scroll Lock key (twice)
+        - Windows/macOS: May not need this, return False
+
+        Returns:
+            bool: True if keep-alive was performed, False otherwise.
+        """
+        pass
+
+# Linux 实现
+class LinuxKeyboardAdapter:
+    async def keep_alive(self) -> bool:
+        # 使用 Scroll Lock 实现
+        return await self._send_scroll_lock_twice()
+
+# Windows 实现
+class WindowsKeyboardAdapter:
+    async def keep_alive(self) -> bool:
+        # Windows 可能不需要此功能
+        return False
+```
+
+### Decision 2: Linux 平台使用 Scroll Lock 按键
+
+**选择理由：**
+- Scroll Lock 在日常使用中极少被触发
+- 对系统状态影响最小（不像 Caps Lock 或 Num Lock 会影响输入）
+- 不会干扰正在运行的应用程序
+- 跨平台支持良好（xdotool, wtype, ydotool 都支持）
+
+**其他考虑方案：**
+- F15/F24 等功能键：虽然更少被使用，但在某些键盘上可能不存在
+- 组合键（如 Ctrl+Shift）：可能触发系统快捷键
+
+### Decision 3: 连续按下两次 Scroll Lock
+
+**选择理由：**
+- 一次按下可能被某些系统忽略
+- 两次按下可以确保系统检测到键盘活动
+- 不会造成任何副作用（Scroll Lock 本身很少被应用使用）
+
+**触发时机：**
+- 启动时立即触发一次
+- 之后每隔 5 分钟自动触发一次
+
+### Decision 4: 使用独立后台线程
+
+**选择理由：**
+- 不阻塞主服务线程
+- 简单可靠的定时实现
+- 易于启动和停止
+- 使用 `threading.Event` 实现优雅关闭
+
+**替代方案：**
+- `asyncio.create_task()`: 需要将整个服务改为异步模式
+- `threading.Timer`: 需要在每次触发后重新创建定时器
+- 外部 cron 任务：增加部署复杂度
+
+### Decision 5: 默认 5 分钟间隔
+
+**选择理由：**
+- Fedora 系统的空闲检测通常在 5-10 分钟后触发
+- 5 分钟间隔足以防止系统检测到空闲
+- 资源开销极低，不会影响性能
+
+**可配置性：**
+- 通过环境变量 `AIPUT_KEEP_ALIVE_INTERVAL` 配置
+- 最小值：1 分钟（防止过于频繁的键盘事件）
+- 单位：秒
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Remote Server                           │
+├─────────────────────────────────────────────────────────────┤
+│                                                               │
+│  ┌───────────────┐        ┌─────────────────────────────┐   │
+│  │ Main Service  │        │   Keep-Alive Thread         │   │
+│  │   (Flask)     │        │                             │   │
+│  └───────────────┘        │  ┌───────────────────────┐  │   │
+│                           │  │  Timer Loop            │  │   │
+│                           │  │  (every 5 min)         │  │   │
+│                           │  └───────────┬───────────┘  │   │
+│                           │              │               │   │
+│                           │  ┌───────────▼───────────┐  │   │
+│                           │  │  keep_alive()         │  │   │
+│                           │  └───────────────────────┘  │   │
+│                           │                             │   │
+│                           └──────────────┬──────────────┘   │
+│                                          │                   │
+│                                          ▼                   │
+│                           ┌─────────────────────────────────┐│
+│                           │     Platform Adapter Factory    ││
+│                           ├─────────────────────────────────┤│
+│                           │  ┌──────────────────────────┐  ││
+│                           │  │  KeyboardAdapter         │  ││
+│                           │  │  ┌────────────────────┐  │  ││
+│                           │  │  │ keep_alive()       │  │  ││
+│                           │  │  │ (generic method)   │  │  ││
+│                           │  │  └────────────────────┘  │  ││
+│                           │  └──────────────────────────┘  ││
+│                           └─────────────────────────────────┘│
+│                                          │                   │
+│                                          ▼                   │
+│                           ┌─────────────────────────────────┐│
+│                           │    Platform Implementations     ││
+│                           ├─────────────────────────────────┤│
+│                           │  • Linux (X11/Wayland)         ││
+│                           │    → keep_alive(): Scroll Lock  ││
+│                           │  • Windows                     ││
+│                           │    → keep_alive(): False/other  ││
+│                           │  • macOS                       ││
+│                           │    → keep_alive(): False/other  ││
+│                           └─────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Interface Definition
+
+### KeyboardAdapter Extension
+
+```python
+class KeyboardAdapter(ABC):
+    # ... existing methods ...
+
+    @abstractmethod
+    async def keep_alive(self) -> bool:
+        """Keep system active to prevent idle detection.
+
+        This is a generic interface - each platform adapter decides
+        the best implementation approach:
+
+        - Linux (Fedora/KDE): Send Scroll Lock key twice
+        - Windows/macOS: May return False if not needed
+
+        Returns:
+            bool: True if keep-alive action was performed successfully,
+                  False if keep-alive is not needed or failed.
+        """
+        pass
+```
+
+### Keep-Alive Thread Implementation
+
+```python
+class KeepAliveThread(threading.Thread):
+    """Background thread that calls keep_alive() periodically."""
+
+    def __init__(self, keyboard_adapter: KeyboardAdapter, interval: int = 300):
+        """Initialize keep-alive thread.
+
+        Args:
+            keyboard_adapter: Platform keyboard adapter for keep-alive.
+            interval: Trigger interval in seconds (default: 300 = 5 minutes).
+        """
+        super().__init__(daemon=True)
+        self._keyboard_adapter = keyboard_adapter
+        self._interval = interval
+        self._stop_event = threading.Event()
+        self._loop = asyncio.new_event_loop()
+
+    def run(self):
+        """Run the keep-alive loop."""
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._keep_alive_loop())
+
+    async def _keep_alive_loop(self):
+        """Keep-alive loop that triggers keep_alive() periodically."""
+        # Immediate trigger on startup
+        await self._trigger_keep_alive()
+
+        while not self._stop_event.is_set():
+            # Wait for interval or stop event
+            self._stop_event.wait(self._interval)
+            if self._stop_event.is_set():
+                break
+            await self._trigger_keep_alive()
+
+    async def _trigger_keep_alive(self):
+        """Trigger keep-alive action."""
+        try:
+            result = await self._keyboard_adapter.keep_alive()
+            if result:
+                logger.debug("Keep-alive triggered successfully")
+            else:
+                logger.debug("Keep-alive not supported or not needed on this platform")
+        except Exception as e:
+            logger.warning(f"Keep-alive trigger failed: {e}")
+
+    def stop(self):
+        """Stop the keep-alive thread gracefully."""
+        self._stop_event.set()
+        self.join(timeout=5)
+```
+
+## Platform-Specific Implementations
+
+### Linux (X11/Wayland) - Scroll Lock Implementation
+
+#### X11KeyboardAdapter
+```python
+async def keep_alive(self) -> bool:
+    """Send Scroll Lock twice using X11 tools."""
+    # Try xdotool
+    if 'xdotool' in self._available_methods:
+        try:
+            subprocess.run(['xdotool', 'key', 'Scroll_Lock'],
+                         check=False, timeout=1)
+            await asyncio.sleep(0.1)
+            subprocess.run(['xdotool', 'key', 'Scroll_Lock'],
+                         check=False, timeout=1)
+            return True
+        except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+            pass
+
+    # Try xte
+    if 'xte' in self._available_methods:
+        try:
+            subprocess.run(['xte', 'key Scroll_Lock'],
+                         check=False, timeout=1)
+            await asyncio.sleep(0.1)
+            subprocess.run(['xte', 'key Scroll_Lock'],
+                         check=False, timeout=1)
+            return True
+        except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+            pass
+
+    return False
+```
+
+#### WaylandKeyboardAdapter
+```python
+async def keep_alive(self) -> bool:
+    """Send Scroll Lock twice using Wayland tools."""
+    # Try xdotool on KDE Wayland (via Xwayland)
+    if 'xdotool (KDE Wayland)' in self._available_methods:
+        try:
+            subprocess.run(['xdotool', 'key', 'Scroll_Lock'],
+                         check=False, timeout=1)
+            await asyncio.sleep(0.1)
+            subprocess.run(['xdotool', 'key', 'Scroll_Lock'],
+                         check=False, timeout=1)
+            return True
+        except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+            pass
+
+    # Try wtype (native Wayland)
+    if 'wtype' in self._available_methods:
+        try:
+            subprocess.run(['wtype', '-P', 'Scroll_Lock'],
+                         check=False, timeout=1)
+            await asyncio.sleep(0.1)
+            subprocess.run(['wtype', '-P', 'Scroll_Lock'],
+                         check=False, timeout=1)
+            return True
+        except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+            pass
+
+    # Try ydotool
+    if 'ydotool' in self._available_methods:
+        try:
+            # ydotool key code for Scroll Lock is 70
+            subprocess.run(['ydotool', 'key', '70:1', '70:0'],
+                         check=False, timeout=1)
+            await asyncio.sleep(0.1)
+            subprocess.run(['ydotool', 'key', '70:1', '70:0'],
+                         check=False, timeout=1)
+            return True
+        except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+            pass
+
+    return False
+```
+
+### Windows - Optional Implementation
+
+```python
+async def keep_alive(self) -> bool:
+    """Keep-alive implementation for Windows.
+
+    Windows may not need this functionality, but can implement
+    using Scroll Lock if needed.
+    """
+    # Option 1: Return False if not needed
+    # return False
+
+    # Option 2: Implement using Scroll Lock
+    if 'pyautogui' in self._methods:
+        try:
+            pyautogui.press('scrolllock')
+            await asyncio.sleep(0.1)
+            pyautogui.press('scrolllock')
+            return True
+        except Exception:
+            pass
+
+    return False
+```
+
+### macOS - Optional Implementation
+
+```python
+async def keep_alive(self) -> bool:
+    """Keep-alive implementation for macOS.
+
+    macOS may not need this functionality, but can implement
+    using Scroll Lock if needed.
+    """
+    # Option 1: Return False if not needed
+    # return False
+
+    # Option 2: Implement using Scroll Lock
+    if 'pyautogui' in self._methods:
+        try:
+            pyautogui.press('scrolllock')
+            await asyncio.sleep(0.1)
+            pyautogui.press('scrolllock')
+            return True
+        except Exception:
+            pass
+
+    return False
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default | Minimum |
+|----------|-------------|---------|---------|
+| `AIPUT_KEEP_ALIVE_ENABLED` | Enable/disable keep-alive feature | `true` | - |
+| `AIPUT_KEEP_ALIVE_INTERVAL` | Trigger interval in seconds | `300` | `60` |
+
+### Configuration File (optional)
+
+```yaml
+keep_alive:
+  enabled: true
+  interval_seconds: 300
+```
+
+## Risks / Trade-offs
+
+### Risk 1: Scroll Lock 可能影响某些应用
+
+**描述：** 某些应用可能监听 Scroll Lock 按键（如某些屏幕阅读器或专业软件）。
+
+**缓解措施：**
+- Scroll Lock 在现代应用中极少被使用
+- 连续按下两次的模式可以避免误触发
+- 如果问题严重，可以添加白名单机制
+
+### Risk 2: 5 分钟间隔可能不够频繁
+
+**描述：** 某些系统可能在更短的时间（如 3 分钟）后检测空闲。
+
+**缓解措施：**
+- 提供可配置的间隔时间
+- 文档说明如何调整间隔
+- 默认 5 分钟适用于大多数情况
+
+### Risk 3: 其他平台可能不需要此功能
+
+**描述：** Windows 和 macOS 可能没有类似 Fedora 的空闲检测问题。
+
+**缓解措施：**
+- 使用通用的 `keep_alive()` 接口
+- 允许平台适配器返回 False 表示不需要
+- Linux 平台实现 Scroll Lock，其他平台可选择实现
+
+### Trade-off: 额外的后台线程
+
+**描述：** 增加了一个后台线程，增加了代码复杂度。
+
+**收益：**
+- 不阻塞主服务
+- 简单可靠的实现
+- 资源开销极低（每 5 分钟一次操作）
+
+## Migration Plan
+
+1. **Phase 1: Add abstract method to base adapter**
+   - Update `KeyboardAdapter` base class with `keep_alive()` method
+   - Document that each platform chooses its implementation
+
+2. **Phase 2: Implement platform-specific methods**
+   - Linux: Implement `keep_alive()` using Scroll Lock
+   - Windows/macOS: Implement stub returning False
+
+3. **Phase 3: Add keep-alive thread**
+   - Create `KeepAliveThread` class
+   - Integrate with main server lifecycle
+
+4. **Phase 4: Add configuration support**
+   - Add environment variable parsing
+   - Add validation for interval values
+
+5. **Phase 5: Testing**
+   - Test on Linux (X11/Wayland/KDE/Fedora)
+   - Verify system idle prevention
+   - Test that other platforms return False gracefully
+
+6. **Phase 6: Documentation**
+   - Update README
+   - Document that implementation varies by platform
+   - Add troubleshooting section
+
+## Open Questions
+
+1. **是否需要在 GUI 中显示 keep-alive 状态？**
+   - 建议：先实现基础功能，后续根据用户反馈决定
+
+2. **是否需要日志记录 keep-alive 触发？**
+   - 建议：添加 debug 级别的日志，方便排查问题
+
+3. **如果 keep-alive 失败，是否需要通知用户？**
+   - 建议：只在失败时记录 warning 日志，不打扰用户
+
+4. **Windows 和 macOS 是否需要实现？**
+   - 建议：先返回 False，如果用户反馈需要再实现
+
+5. **是否需要支持不同的保持激活策略？**
+   - 建议：先使用 Scroll Lock（Linux），如果用户反馈有问题，再考虑添加配置选项

--- a/openspec/changes/archive/2026-01-01-keep-alive-keyboard-activity/proposal.md
+++ b/openspec/changes/archive/2026-01-01-keep-alive-keyboard-activity/proposal.md
@@ -1,0 +1,34 @@
+# Change: Add Keep-Alive Keyboard Activity
+
+**Status:** ExecutionCompleted
+
+## Why
+
+在 Fedora 系统上，当用户长时间不进行输入操作时，系统会弹出键盘输入相关的提示或检测通知，打断正常工作流程并需要手动关闭。这会影响 AIPut 的用户体验，特别是在需要长时间保持后台运行的情况下。
+
+## What Changes
+
+- 在 `KeyboardAdapter` 基类中添加 `keep_alive()` 抽象方法
+  - 使用通用方法名 `keep_alive()` 而非具体实现名
+  - 每个平台适配器根据自身特点选择最合适的保持激活实现方式
+- 为所有平台适配器实现 `keep_alive()` 方法：
+  - Linux (X11/Wayland/Fedora/KDE): 使用 Scroll Lock 按键（连续按下两次）
+    - X11: 使用 xdotool/xte/xvkbd 模拟
+    - Wayland: 使用 wtype/ydotool 模拟
+    - KDE Wayland: 可使用 xdotool 通过 Xwayland
+  - Windows/macOS: 预留接口，可根据需要实现（也可使用 Scroll Lock）
+- 在主服务器中实现后台保持激活机制：
+  - 启动时立即触发一次 keep-alive
+  - 使用独立线程每隔 5 分钟自动触发一次
+- 添加可配置的保持激活间隔时间（通过环境变量或配置文件）
+
+## Impact
+
+- Affected specs: `platform-abstraction`
+- Affected code:
+  - `src/platform_adapters/base.py` - 添加抽象方法 `keep_alive()`
+  - `src/platform_adapters/linux/wayland.py` - 实现 `keep_alive()` (使用 Scroll Lock)
+  - `src/platform_adapters/linux/x11.py` - 实现 `keep_alive()` (使用 Scroll Lock)
+  - `src/platform_adapters/windows/adapter.py` - 实现 `keep_alive()` (预留)
+  - `src/platform_adapters/macos/adapter.py` - 实现 `keep_alive()` (预留)
+  - `src/remote_server.py` - 添加保持激活线程

--- a/openspec/changes/archive/2026-01-01-keep-alive-keyboard-activity/specs/platform-abstraction/spec.md
+++ b/openspec/changes/archive/2026-01-01-keep-alive-keyboard-activity/specs/platform-abstraction/spec.md
@@ -1,0 +1,131 @@
+# platform-abstraction Specification
+
+## ADDED Requirements
+
+### Requirement: Platform Adapter Factory
+The system SHALL provide a factory pattern for creating platform-specific adapters based on the detected operating system and display environment.
+
+#### Scenario: Create adapter for detected platform
+- **WHEN** the system starts up on a detected platform
+- **THEN** the factory creates the appropriate platform adapter
+- **AND** the adapter provides interfaces for keyboard, clipboard, and system tray operations
+
+#### Scenario: Fallback for unsupported platforms
+- **WHEN** the platform is not explicitly supported
+- **THEN** the factory provides a generic adapter with limited functionality
+- **AND** the system logs a warning about limited support
+
+### Requirement: Keyboard Adapter Interface
+The system SHALL provide a keyboard adapter interface for simulating keyboard input across different platforms.
+
+#### Scenario: Send paste command
+- **WHEN** the application needs to paste clipboard content
+- **THEN** the keyboard adapter sends the appropriate paste key combination
+- **AND** the key combination is platform-specific (Shift+Insert or Ctrl+V/Cmd+V)
+
+#### Scenario: Detect available keyboard methods
+- **WHEN** the keyboard adapter initializes
+- **THEN** it detects available keyboard simulation tools
+- **AND** provides a list of available methods
+
+### Requirement: Clipboard Adapter Interface
+The system SHALL provide a clipboard adapter interface for clipboard operations across different platforms.
+
+#### Scenario: Copy text to clipboard
+- **WHEN** text needs to be copied to the clipboard
+- **THEN** the clipboard adapter uses the appropriate platform-specific method
+- **AND** returns success status
+
+#### Scenario: Setup clipboard support
+- **WHEN** the application starts
+- **THEN** the clipboard adapter initializes platform-specific clipboard support
+
+### Requirement: System Tray Adapter Interface
+The system SHALL provide a system tray adapter interface for system tray integration.
+
+#### Scenario: Create tray icon
+- **WHEN** the application starts in GUI mode
+- **THEN** the system tray adapter creates a tray icon with menu items
+- **AND** the icon is displayed in the system tray
+
+#### Scenario: Check system tray support
+- **WHEN** the system tray adapter is queried
+- **THEN** it reports whether system tray is supported on the platform
+
+### Requirement: Resource Adapter Interface
+The system SHALL provide a resource adapter interface for accessing application resources.
+
+#### Scenario: Get icon path
+- **WHEN** the application needs to load an icon
+- **THEN** the resource adapter locates the icon file
+- **AND** returns the absolute path to the icon
+
+#### Scenario: Load image
+- **WHEN** an image file needs to be loaded
+- **THEN** the resource adapter loads the image using platform-appropriate method
+
+### Requirement: Notification Adapter Interface
+The system SHALL provide a notification adapter interface for system notifications.
+
+#### Scenario: Play notification sound
+- **WHEN** a notification sound is requested
+- **THEN** the notification adapter plays a sound using platform-appropriate method
+- **AND** handles errors gracefully if sound playback fails
+
+### Requirement: Keyboard Keep-Alive
+The keyboard adapter SHALL provide a generic `keep_alive()` method that each platform adapter implements according to its specific needs.
+
+#### Scenario: Keep-alive on Linux (Fedora/KDE)
+- **WHEN** the keep-alive mechanism is triggered on Linux
+- **THEN** the keyboard adapter sends Scroll Lock key press twice
+- **AND** uses platform-specific keyboard simulation tools (xdotool, wtype, ydotool)
+- **AND** returns success status
+
+#### Scenario: Keep-alive on Linux X11
+- **WHEN** running on Linux with X11 display server
+- **THEN** the keyboard adapter uses xdotool, xte, or xvkbd to send Scroll Lock
+- **AND** tries available tools in fallback order
+
+#### Scenario: Keep-alive on Linux Wayland
+- **WHEN** running on Linux with Wayland display server
+- **THEN** the keyboard adapter uses wtype, ydotool, or xdotool (KDE Wayland) to send Scroll Lock
+- **AND** tries available tools in fallback order
+
+#### Scenario: Keep-alive on Windows (optional)
+- **WHEN** running on Windows
+- **THEN** the keyboard adapter may return False if keep-alive is not needed
+- **OR** may implement keep-alive using platform-specific methods if needed
+
+#### Scenario: Keep-alive on macOS (optional)
+- **WHEN** running on macOS
+- **THEN** the keyboard adapter may return False if keep-alive is not needed
+- **OR** may implement keep-alive using platform-specific methods if needed
+
+#### Scenario: Generic keep-alive interface
+- **WHEN** any platform adapter implements keep-alive
+- **THEN** the implementation is chosen based on platform-specific requirements
+- **AND** the method name `keep_alive()` is generic and platform-agnostic
+- **AND** the return value indicates whether keep-alive was performed (True) or not needed (False)
+
+### Requirement: Platform-Specific Keyboard Tools Detection
+The keyboard adapter SHALL detect and use platform-specific keyboard simulation tools with proper fallback chains.
+
+#### Scenario: Detect X11 keyboard tools
+- **WHEN** running on Linux with X11 display server
+- **THEN** the adapter detects availability of xdotool, xte, and xvkbd
+- **AND** prioritizes tools in order: xdotool, xte, xvkbd
+
+#### Scenario: Detect Wayland keyboard tools
+- **WHEN** running on Linux with Wayland display server
+- **THEN** the adapter detects availability of wtype, ydotool, and xdotool (for KDE Wayland)
+- **AND** prioritizes tools in order: xdotool (KDE Wayland), wtype, ydotool
+
+#### Scenario: Detect Windows keyboard methods
+- **WHEN** running on Windows
+- **THEN** the adapter detects availability of pyautogui and win32api
+- **AND** prioritizes methods in order: pyautogui, win32api
+
+#### Scenario: Detect macOS keyboard methods
+- **WHEN** running on macOS
+- **THEN** the adapter detects availability of pyautogui and osascript
+- **AND** prioritizes methods in order: pyautogui, osascript

--- a/openspec/changes/archive/2026-01-01-keep-alive-keyboard-activity/tasks.md
+++ b/openspec/changes/archive/2026-01-01-keep-alive-keyboard-activity/tasks.md
@@ -1,0 +1,70 @@
+## 1. Update Platform Adapter Base Interface
+- [x] 1.1 Add `keep_alive()` abstract method to `KeyboardAdapter` in `base.py`
+  - Use generic method name instead of implementation-specific name
+  - Each platform adapter decides how to implement keep-alive
+- [x] 1.2 Add documentation for the new method
+
+## 2. Implement keep_alive() for Linux (X11/Wayland)
+- [x] 2.1 Implement `keep_alive()` in `WaylandKeyboardAdapter`
+  - [x] 2.1.1 Use Scroll Lock key (press twice) for Fedora/KDE Wayland
+  - [x] 2.1.2 Add xdotool support via Xwayland
+  - [x] 2.1.3 Add wtype support for native Wayland
+  - [x] 2.1.4 Add ydotool support as fallback
+- [x] 2.2 Implement `keep_alive()` in `X11KeyboardAdapter`
+  - [x] 2.2.1 Use Scroll Lock key (press twice)
+  - [x] 2.2.2 Add xdotool support
+  - [x] 2.2.3 Add xte support
+  - [x] 2.2.4 Add xvkbd support
+
+## 3. Implement keep_alive() for Windows
+- [x] 3.1 Implement `keep_alive()` in `WindowsKeyboardAdapter`
+  - [x] 3.1.1 Add stub implementation returning False (platform may not need this)
+  - [x] 3.1.2 Optionally implement Scroll Lock using pyautogui/win32api
+
+## 4. Implement keep_alive() for macOS
+- [x] 4.1 Implement `keep_alive()` in `MacOSKeyboardAdapter`
+  - [x] 4.1.1 Add stub implementation returning False (platform may not need this)
+  - [x] 4.1.2 Optionally implement Scroll Lock using pyautogui/osascript
+
+## 5. Implement Keep-Alive Thread in Main Server
+- [x] 5.1 Create `KeepAliveThread` class in `remote_server.py`
+  - [x] 5.1.1 Implement thread-safe start/stop mechanism
+  - [x] 5.1.2 Add configurable interval (default: 5 minutes)
+  - [x] 5.1.3 Call `keyboard_adapter.keep_alive()` periodically
+- [x] 5.2 Integrate keep-alive thread with main server lifecycle
+  - [x] 5.2.1 Start keep-alive thread on server startup
+  - [x] 5.2.2 Stop keep-alive thread gracefully on shutdown
+  - [x] 5.2.3 Add initial keep-alive trigger on startup
+
+## 6. Add Configuration Support
+- [x] 6.1 Add environment variable support for keep-alive interval
+  - [x] 6.1.1 Define `AIPUT_KEEP_ALIVE_INTERVAL` environment variable
+  - [x] 6.1.2 Add validation for interval values (minimum: 1 minute)
+- [ ] 6.2 Add configuration file support (optional)
+  - [ ] 6.2.1 Add keep-alive settings to config file schema
+  - [ ] 6.2.2 Implement config loading logic
+
+## 7. Testing and Validation
+- [ ] 7.1 Test keep-alive on Linux (X11)
+  - [ ] 7.1.1 Verify Scroll Lock simulation with xdotool
+  - [ ] 7.1.2 Verify Scroll Lock simulation with xte (if available)
+- [ ] 7.2 Test keep-alive on Linux (Wayland)
+  - [ ] 7.2.1 Verify Scroll Lock simulation on KDE Wayland (xdotool via Xwayland)
+  - [ ] 7.2.2 Verify Scroll Lock simulation with wtype
+  - [ ] 7.2.3 Verify Scroll Lock simulation with ydotool
+- [ ] 7.3 Test keep-alive on Windows (if implemented)
+- [ ] 7.4 Test keep-alive on macOS (if implemented)
+- [ ] 7.5 Test keep-alive thread functionality
+  - [ ] 7.5.1 Verify initial trigger on startup
+  - [ ] 7.5.2 Verify periodic triggers every 5 minutes
+  - [ ] 7.5.3 Verify graceful shutdown
+- [ ] 7.6 Test custom interval configuration
+- [ ] 7.7 Verify system idle prevention on Fedora/KDE
+  - [ ] 7.7.1 Run for extended period (> 15 minutes)
+  - [ ] 7.7.2 Confirm no system keyboard input prompts appear
+
+## 8. Documentation
+- [ ] 8.1 Update README with keep-alive feature description
+- [ ] 8.2 Document environment variable configuration
+- [ ] 8.3 Add troubleshooting section for keep-alive issues
+- [ ] 8.4 Document that Linux uses Scroll Lock, other platforms may have different implementations

--- a/openspec/specs/platform-abstraction/spec.md
+++ b/openspec/specs/platform-abstraction/spec.md
@@ -1,0 +1,133 @@
+# platform-abstraction Specification
+
+## Purpose
+TBD - created by archiving change keep-alive-keyboard-activity. Update Purpose after archive.
+## Requirements
+### Requirement: Platform Adapter Factory
+The system SHALL provide a factory pattern for creating platform-specific adapters based on the detected operating system and display environment.
+
+#### Scenario: Create adapter for detected platform
+- **WHEN** the system starts up on a detected platform
+- **THEN** the factory creates the appropriate platform adapter
+- **AND** the adapter provides interfaces for keyboard, clipboard, and system tray operations
+
+#### Scenario: Fallback for unsupported platforms
+- **WHEN** the platform is not explicitly supported
+- **THEN** the factory provides a generic adapter with limited functionality
+- **AND** the system logs a warning about limited support
+
+### Requirement: Keyboard Adapter Interface
+The system SHALL provide a keyboard adapter interface for simulating keyboard input across different platforms.
+
+#### Scenario: Send paste command
+- **WHEN** the application needs to paste clipboard content
+- **THEN** the keyboard adapter sends the appropriate paste key combination
+- **AND** the key combination is platform-specific (Shift+Insert or Ctrl+V/Cmd+V)
+
+#### Scenario: Detect available keyboard methods
+- **WHEN** the keyboard adapter initializes
+- **THEN** it detects available keyboard simulation tools
+- **AND** provides a list of available methods
+
+### Requirement: Clipboard Adapter Interface
+The system SHALL provide a clipboard adapter interface for clipboard operations across different platforms.
+
+#### Scenario: Copy text to clipboard
+- **WHEN** text needs to be copied to the clipboard
+- **THEN** the clipboard adapter uses the appropriate platform-specific method
+- **AND** returns success status
+
+#### Scenario: Setup clipboard support
+- **WHEN** the application starts
+- **THEN** the clipboard adapter initializes platform-specific clipboard support
+
+### Requirement: System Tray Adapter Interface
+The system SHALL provide a system tray adapter interface for system tray integration.
+
+#### Scenario: Create tray icon
+- **WHEN** the application starts in GUI mode
+- **THEN** the system tray adapter creates a tray icon with menu items
+- **AND** the icon is displayed in the system tray
+
+#### Scenario: Check system tray support
+- **WHEN** the system tray adapter is queried
+- **THEN** it reports whether system tray is supported on the platform
+
+### Requirement: Resource Adapter Interface
+The system SHALL provide a resource adapter interface for accessing application resources.
+
+#### Scenario: Get icon path
+- **WHEN** the application needs to load an icon
+- **THEN** the resource adapter locates the icon file
+- **AND** returns the absolute path to the icon
+
+#### Scenario: Load image
+- **WHEN** an image file needs to be loaded
+- **THEN** the resource adapter loads the image using platform-appropriate method
+
+### Requirement: Notification Adapter Interface
+The system SHALL provide a notification adapter interface for system notifications.
+
+#### Scenario: Play notification sound
+- **WHEN** a notification sound is requested
+- **THEN** the notification adapter plays a sound using platform-appropriate method
+- **AND** handles errors gracefully if sound playback fails
+
+### Requirement: Keyboard Keep-Alive
+The keyboard adapter SHALL provide a generic `keep_alive()` method that each platform adapter implements according to its specific needs.
+
+#### Scenario: Keep-alive on Linux (Fedora/KDE)
+- **WHEN** the keep-alive mechanism is triggered on Linux
+- **THEN** the keyboard adapter sends Scroll Lock key press twice
+- **AND** uses platform-specific keyboard simulation tools (xdotool, wtype, ydotool)
+- **AND** returns success status
+
+#### Scenario: Keep-alive on Linux X11
+- **WHEN** running on Linux with X11 display server
+- **THEN** the keyboard adapter uses xdotool, xte, or xvkbd to send Scroll Lock
+- **AND** tries available tools in fallback order
+
+#### Scenario: Keep-alive on Linux Wayland
+- **WHEN** running on Linux with Wayland display server
+- **THEN** the keyboard adapter uses wtype, ydotool, or xdotool (KDE Wayland) to send Scroll Lock
+- **AND** tries available tools in fallback order
+
+#### Scenario: Keep-alive on Windows (optional)
+- **WHEN** running on Windows
+- **THEN** the keyboard adapter may return False if keep-alive is not needed
+- **OR** may implement keep-alive using platform-specific methods if needed
+
+#### Scenario: Keep-alive on macOS (optional)
+- **WHEN** running on macOS
+- **THEN** the keyboard adapter may return False if keep-alive is not needed
+- **OR** may implement keep-alive using platform-specific methods if needed
+
+#### Scenario: Generic keep-alive interface
+- **WHEN** any platform adapter implements keep-alive
+- **THEN** the implementation is chosen based on platform-specific requirements
+- **AND** the method name `keep_alive()` is generic and platform-agnostic
+- **AND** the return value indicates whether keep-alive was performed (True) or not needed (False)
+
+### Requirement: Platform-Specific Keyboard Tools Detection
+The keyboard adapter SHALL detect and use platform-specific keyboard simulation tools with proper fallback chains.
+
+#### Scenario: Detect X11 keyboard tools
+- **WHEN** running on Linux with X11 display server
+- **THEN** the adapter detects availability of xdotool, xte, and xvkbd
+- **AND** prioritizes tools in order: xdotool, xte, xvkbd
+
+#### Scenario: Detect Wayland keyboard tools
+- **WHEN** running on Linux with Wayland display server
+- **THEN** the adapter detects availability of wtype, ydotool, and xdotool (for KDE Wayland)
+- **AND** prioritizes tools in order: xdotool (KDE Wayland), wtype, ydotool
+
+#### Scenario: Detect Windows keyboard methods
+- **WHEN** running on Windows
+- **THEN** the adapter detects availability of pyautogui and win32api
+- **AND** prioritizes methods in order: pyautogui, win32api
+
+#### Scenario: Detect macOS keyboard methods
+- **WHEN** running on macOS
+- **THEN** the adapter detects availability of pyautogui and osascript
+- **AND** prioritizes methods in order: pyautogui, osascript
+

--- a/src/platform_adapters/base.py
+++ b/src/platform_adapters/base.py
@@ -65,6 +65,22 @@ class KeyboardAdapter(ABC):
         """
         return False
 
+    @abstractmethod
+    async def keep_alive(self) -> bool:
+        """Keep system active to prevent idle detection.
+
+        This is a generic interface - each platform adapter decides
+        the best implementation approach:
+
+        - Linux (Fedora/KDE): Send Scroll Lock key twice
+        - Windows/macOS: May return False if not needed
+
+        Returns:
+            bool: True if keep-alive action was performed successfully,
+                  False if keep-alive is not needed or failed.
+        """
+        pass
+
 
 class ClipboardAdapter(ABC):
     """Abstract interface for clipboard operations."""

--- a/src/platform_adapters/linux/adapter.py
+++ b/src/platform_adapters/linux/adapter.py
@@ -103,6 +103,22 @@ class LinuxKeyboardAdapter(KeyboardAdapter):
 
         return methods
 
+    async def send_text(self, text: str) -> bool:
+        """Send text directly using the specific adapter if available."""
+        if self._specific_adapter:
+            return await self._specific_adapter.send_text(text)
+        return False
+
+    async def keep_alive(self) -> bool:
+        """Keep-alive implementation using Scroll Lock key.
+
+        Returns:
+            bool: True if keep-alive was performed successfully, False otherwise.
+        """
+        if self._specific_adapter:
+            return await self._specific_adapter.keep_alive()
+        return False
+
 
 class LinuxClipboardAdapter(ClipboardAdapter):
     """Linux clipboard adapter supporting multiple tools."""

--- a/src/platform_adapters/linux/wayland.py
+++ b/src/platform_adapters/linux/wayland.py
@@ -119,3 +119,49 @@ class WaylandKeyboardAdapter(KeyboardAdapter):
             except (subprocess.SubprocessError, subprocess.TimeoutExpired):
                 pass
         return False
+
+    async def keep_alive(self) -> bool:
+        """Send Scroll Lock twice using Wayland-compatible methods.
+
+        Returns:
+            bool: True if keep-alive was performed successfully, False otherwise.
+        """
+        # Try xdotool on KDE Wayland (via Xwayland)
+        if 'xdotool (KDE Wayland)' in self._available_methods:
+            try:
+                subprocess.run(['xdotool', 'key', 'Scroll_Lock'],
+                             check=False, timeout=1)
+                await asyncio.sleep(0.1)
+                subprocess.run(['xdotool', 'key', 'Scroll_Lock'],
+                             check=False, timeout=1)
+                return True
+            except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+                pass
+
+        # Try wtype (native Wayland)
+        if 'wtype' in self._available_methods:
+            try:
+                # wtype -P Scroll_Lock (press and release)
+                subprocess.run(['wtype', '-P', 'Scroll_Lock'],
+                             check=False, timeout=1)
+                await asyncio.sleep(0.1)
+                subprocess.run(['wtype', '-P', 'Scroll_Lock'],
+                             check=False, timeout=1)
+                return True
+            except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+                pass
+
+        # Try ydotool
+        if 'ydotool' in self._available_methods:
+            try:
+                # ydotool key code for Scroll Lock is 70
+                subprocess.run(['ydotool', 'key', '70:1', '70:0'],
+                             check=False, timeout=1)
+                await asyncio.sleep(0.1)
+                subprocess.run(['ydotool', 'key', '70:1', '70:0'],
+                             check=False, timeout=1)
+                return True
+            except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+                pass
+
+        return False

--- a/src/platform_adapters/linux/x11.py
+++ b/src/platform_adapters/linux/x11.py
@@ -124,3 +124,47 @@ class X11KeyboardAdapter(KeyboardAdapter):
                 pass
 
         return False
+
+    async def keep_alive(self) -> bool:
+        """Send Scroll Lock twice using X11-compatible methods.
+
+        Returns:
+            bool: True if keep-alive was performed successfully, False otherwise.
+        """
+        # Try xdotool
+        if 'xdotool' in self._available_methods:
+            try:
+                subprocess.run(['xdotool', 'key', 'Scroll_Lock'],
+                             check=False, timeout=1)
+                await asyncio.sleep(0.1)
+                subprocess.run(['xdotool', 'key', 'Scroll_Lock'],
+                             check=False, timeout=1)
+                return True
+            except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+                pass
+
+        # Try xte
+        if 'xte' in self._available_methods:
+            try:
+                subprocess.run(['xte', 'key Scroll_Lock'],
+                             check=False, timeout=1)
+                await asyncio.sleep(0.1)
+                subprocess.run(['xte', 'key Scroll_Lock'],
+                             check=False, timeout=1)
+                return True
+            except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+                pass
+
+        # Try xvkbd
+        if 'xvkbd' in self._available_methods:
+            try:
+                subprocess.run(['xvkbd', '-text', '\\[Scroll_Lock]'],
+                             check=False, timeout=1)
+                await asyncio.sleep(0.1)
+                subprocess.run(['xvkbd', '-text', '\\[Scroll_Lock]'],
+                             check=False, timeout=1)
+                return True
+            except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+                pass
+
+        return False

--- a/src/platform_adapters/macos/adapter.py
+++ b/src/platform_adapters/macos/adapter.py
@@ -141,6 +141,19 @@ class MacOSKeyboardAdapter(KeyboardAdapter):
                 pass
         return False
 
+    async def keep_alive(self) -> bool:
+        """Keep-alive implementation for macOS.
+
+        macOS may not need this functionality, but can implement
+        using Scroll Lock if needed.
+
+        Returns:
+            bool: True if keep-alive was performed successfully, False otherwise.
+        """
+        # macOS typically doesn't need this feature
+        # Return False to indicate not needed
+        return False
+
 
 class MacOSClipboardAdapter(ClipboardAdapter):
     """macOS clipboard adapter."""

--- a/src/platform_adapters/windows/adapter.py
+++ b/src/platform_adapters/windows/adapter.py
@@ -152,6 +152,19 @@ class WindowsKeyboardAdapter(KeyboardAdapter):
                 pass
         return False
 
+    async def keep_alive(self) -> bool:
+        """Keep-alive implementation for Windows.
+
+        Windows may not need this functionality, but can implement
+        using Scroll Lock if needed.
+
+        Returns:
+            bool: True if keep-alive was performed successfully, False otherwise.
+        """
+        # Windows typically doesn't need this feature
+        # Return False to indicate not needed
+        return False
+
 
 class WindowsClipboardAdapter(ClipboardAdapter):
     """Windows clipboard adapter."""


### PR DESCRIPTION
Adds a keep-alive mechanism to prevent system idle detection on Linux (Fedora/KDE) by simulating keyboard activity.

This includes:
- A generic `keep_alive()` method in the `KeyboardAdapter` interface.
- Platform-specific implementations for Linux (X11/Wayland) using Scroll Lock key events.
- A background thread to trigger the keep-alive mechanism periodically.
- Configuration options for the trigger interval.

The keep-alive feature addresses the issue of the system prompting for keyboard input or interrupting automated input when the user is idle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a cross-platform keep-alive mechanism that simulates keyboard activity at configurable intervals (default 5 minutes) on Linux, Windows, and macOS, with configuration via environment variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->